### PR TITLE
feat(projects): Add dynamic project links and button labels

### DIFF
--- a/public/assets/styles.css
+++ b/public/assets/styles.css
@@ -553,6 +553,11 @@ img {
   display: flex;
   gap: var(--spacing-md);
 }
+.project-buttons {
+  display: flex;
+  gap: var(--spacing-md);
+  padding: 1rem 0;
+}
 
 /* ============================================
    CHIPS COMPONENTS

--- a/src/components/Project.astro
+++ b/src/components/Project.astro
@@ -1,5 +1,5 @@
 ---
-const { title, desc, tech } = Astro.props
+const { title, url, rel, anchor, desc, tech } = Astro.props
 import { preventOrphans } from '../scripts/helpers'
 
 const array = title.split(' | ')
@@ -12,6 +12,18 @@ const array = title.split(' | ')
     >
     <span class="line bold-600" style="font-size: 1.5rem;">{array[1]}</span>
   </h3>
+  {
+    url && anchor && (
+      <div class="project-buttons">
+        {url && (
+          <a href={url} target="_blank" rel={rel} class="button w-button">
+            {anchor}
+          </a>
+        )}
+      </div>
+    )
+  }
+
   <div class="project-desc project-desc-list w-richtext">
     <ul role="list">
       {desc.map((item) => <li>{preventOrphans(item)}</li>)}

--- a/src/pages/aplikacje-webowe.astro
+++ b/src/pages/aplikacje-webowe.astro
@@ -6,11 +6,17 @@ import BackButton from '../components/BackButton.astro'
 const projects = [
   {
     title: '2025 | Codefolio MCh',
+    url: '',
+    rel: 'noopener noreferrer',
+    anchor: '',
     desc: ['Prace w toku'],
     tech: ['Astro', 'JavaScript', 'CSS'],
   },
   {
     title: '2024 | iChip WebApp | Demo',
+    url: 'https://ichip-webapp.vercel.app/',
+    rel: 'noopener noreferrer',
+    anchor: 'Zobacz demo',
     desc: [
       'Projekt i wdrożenie prototypu aplikacji webowej dla serwisu urządzeń mobilnych',
       'Zaawansowany formularz z walidacją do składania zleceń napraw online',
@@ -53,6 +59,9 @@ const projects = [
                   projects.map((project) => (
                     <Project
                       title={project.title}
+                      url={project.url}
+                      rel={project.rel}
+                      anchor={project.anchor}
                       desc={project.desc}
                       tech={project.tech}
                     />

--- a/src/pages/seo-pozycjonowanie.astro
+++ b/src/pages/seo-pozycjonowanie.astro
@@ -6,6 +6,9 @@ import BackButton from '../components/BackButton.astro'
 const projects = [
   {
     title: '2021-2025 | Projekty Klientów',
+    url: '',
+    rel: '',
+    anchor: '',
     desc: [
       'Optymalizacja SEO jako integralna część projektów stron i sklepów internetowych',
       'Audyty techniczne SEO i wdrażanie najlepszych praktyk on-site podczas developmentu',
@@ -25,6 +28,9 @@ const projects = [
   },
   {
     title: '2019-2021 | K2 Precise S.A. | Warszawa',
+    url: 'https://k2precise.pl/',
+    rel: 'noopener noreferrer nofollow',
+    anchor: 'Odwiedź stronę',
     desc: [
       'Tworzenie i optymalizacja treści blogowych zgodnie z najlepszymi praktykami SEO',
       'Opracowanie treści i metadanych dla materiałów wideo: tytuły, opisy, transkrypcje/napisy',
@@ -42,6 +48,9 @@ const projects = [
   },
   {
     title: '2017-2019 | Centrum Kształcenia Proeuropejskiego | Lublin',
+    url: 'https://ckp.lublin.pl/',
+    rel: 'noopener noreferrer nofollow',
+    anchor: 'Odwiedź stronę',
     desc: [
       'Prowadzenie szkoleń z zakresu tworzenia, optymalizacji SEO i pozycjonowania stron internetowych w ramach projektów unijnych',
       'Współpraca przy optymalizacji on-site i off-site strony firmowej',
@@ -59,6 +68,9 @@ const projects = [
   },
   {
     title: '2015-2017 | Performance Media | Lublin',
+    url: 'https://performancegroup.pl/',
+    rel: 'noopener noreferrer nofollow',
+    anchor: 'Odwiedź stronę',
     desc: [
       'Planowanie i wdrażanie strategii SEO dla stron internetowych klientów agencji',
       'Audyty techniczne SEO: analiza treści, wydajności i struktury witryn',
@@ -102,6 +114,9 @@ const projects = [
                   projects.map((project) => (
                     <Project
                       title={project.title}
+                      url={project.url}
+                      rel={project.rel}
+                      anchor={project.anchor}
                       desc={project.desc}
                       tech={project.tech}
                     />

--- a/src/pages/strony-sklepy.astro
+++ b/src/pages/strony-sklepy.astro
@@ -6,6 +6,9 @@ import BackButton from '../components/BackButton.astro'
 const projects = [
   {
     title: '2025 | Winnica Koniczynowe Wzgórze | Puławy',
+    url: '',
+    rel: 'noopener noreferrer nofollow',
+    anchor: '',
     desc: [
       'Stworzenie kompletnej identyfikacji wizualnej: logo, etykiety, nadruki, odzież firmowa',
       'Konsultacje brandingowe i pilnowanie spójnej komunikacji wizualnej',
@@ -24,6 +27,9 @@ const projects = [
   },
   {
     title: '2024 | WaterFamily | Radom',
+    url: 'https://waterfamily.com.pl/',
+    rel: 'noopener noreferrer nofollow',
+    anchor: 'Zobacz sklep',
     desc: [
       'Kompleksowe wdrożenie sklepu internetowego WooCommerce (motyw Neve) dostosowanego do sprzedaży 200+ produktów',
       'Optymalizacja techniczna i wydajnościowa: hosting, SSL, DNS, CDN',
@@ -45,6 +51,9 @@ const projects = [
   },
   {
     title: '2023 | HurtGSM | Radom',
+    url: 'https://hurtgsm.pl/',
+    rel: 'noopener noreferrer nofollow',
+    anchor: 'Zobacz sklep',
     desc: [
       'Wdrożenie skalowalnego sklepu WooCommerce (motyw Porto) z dedykowanymi modyfikacjami front-endu i wtyczek',
       'Integracja z wieloma systemami: kurierzy (InPost, Pocztex, Żabka, Orlen, PP), płatności (Tpay), platforma multichannel Sellasist',
@@ -68,6 +77,9 @@ const projects = [
   },
   {
     title: '2022 | WedzIGrilluj | Lublin',
+    url: 'https://wedzigrilluj.pl/',
+    rel: 'noopener noreferrer nofollow',
+    anchor: 'Zobacz sklep',
     desc: [
       'Migracja PrestaShop do WooCommerce + przekierowaia 301 (utrzymanie pozycji w Google)',
       'Projekt i wdrożenie sklepu (motyw Maison) zoptymalizowanego pod UX i konwersję',
@@ -91,6 +103,9 @@ const projects = [
   },
   {
     title: '2021 | ClubGarden | Radom',
+    url: 'https://clubgarden.pl/',
+    rel: 'noopener noreferrer nofollow',
+    anchor: 'Zobacz sklep',
     desc: [
       'Wdrożenie sklepu WooCommerce (motyw Unero) z nowoczesnym designem',
       'Pełna konfiguracja techniczna: hosting, domena, SSL, DNS, FTP',
@@ -122,6 +137,9 @@ const projects = [
                   projects.map((project) => (
                     <Project
                       title={project.title}
+                      url={project.url}
+                      rel={project.rel}
+                      anchor={project.anchor}
                       desc={project.desc}
                       tech={project.tech}
                     />


### PR DESCRIPTION
This commit introduces dynamic linking for project entries, allowing for varied button labels and `rel` attributes based on project type.

- Implemented `url`, `anchor`, and `rel` properties in project data.
- Updated `Project.astro` to conditionally render project buttons.
- Configured `rel="noopener noreferrer nofollow"` for external client/employer links.
- Defined specific button labels:
    - "Zobacz aplikację" / "Zobacz demo" for web applications.
    - "Zobacz stronę" / "Zobacz sklep" for client websites/e-commerce.
    - "Odwiedź stronę" for SEO case studies.
- Minor styling adjustments for `.project-buttons` section.